### PR TITLE
feat: RAG query layer with LLM integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,23 @@ EMBEDDING_PROVIDER=local
 # Local model (sentence-transformers) — used when EMBEDDING_PROVIDER=local
 EMBEDDING_MODEL=all-MiniLM-L6-v2
 
-# ---- OpenAI (required when EMBEDDING_PROVIDER=openai) ------
+# ---- OpenAI (required when EMBEDDING_PROVIDER=openai or LLM_PROVIDER=openai) ------
 OPENAI_API_KEY=
+
+# ---- LLM provider ------------------------------------------
+# Options: openai | ollama
+LLM_PROVIDER=openai
+
+# LLM model name
+#   OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo, ...
+#   Ollama: llama3, mistral, gemma, ...
+LLM_MODEL=gpt-4o
+
+# ---- Ollama (required when LLM_PROVIDER=ollama) ------------
+OLLAMA_HOST=http://localhost:11434
+
+# ---- API authentication ------------------------------------
+# Leave blank to disable auth (dev mode only)
+API_KEY=
+# Admin key for privileged endpoints (/ingest). Falls back to API_KEY if blank.
+ADMIN_API_KEY=

--- a/config.py
+++ b/config.py
@@ -35,6 +35,28 @@ class Settings(BaseSettings):
     # OpenAI
     openai_api_key: str = Field(default="", description="OpenAI API key")
 
+    # API authentication
+    api_key: str = Field(default="", description="API key for /api/v1/* endpoints")
+    admin_api_key: str = Field(
+        default="",
+        description="Admin API key for privileged endpoints (e.g. /ingest). "
+                    "Falls back to api_key when not set.",
+    )
+
+    # LLM
+    llm_provider: str = Field(
+        default="openai",
+        description="LLM provider: 'openai' or 'ollama'",
+    )
+    llm_model: str = Field(
+        default="gpt-4o",
+        description="LLM model name (e.g. gpt-4o, llama3)",
+    )
+    ollama_host: str = Field(
+        default="http://localhost:11434",
+        description="Ollama API base URL",
+    )
+
     @property
     def has_eurlex_credentials(self) -> bool:
         """True when SOAP credentials are configured."""

--- a/rag/chain.py
+++ b/rag/chain.py
@@ -1,0 +1,198 @@
+"""RAG Chain — orchestrates embed → retrieve → prompt → LLM.
+
+Public API
+----------
+>>> from rag.chain import RAGChain
+>>> chain = RAGChain()
+>>> result = chain.query("What are the ICT risk management requirements under DORA?")
+>>> print(result["answer"])
+>>> for citation in result["citations"]:
+...     print(citation)
+
+Streaming variant::
+
+>>> for chunk in chain.query("...", stream=True):
+...     print(chunk, end="", flush=True)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Generator, Iterator, Optional, Union
+
+from rag.prompt import assemble_prompt, format_citation
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# RAGChain
+# ---------------------------------------------------------------------------
+
+
+class RAGChain:
+    """End-to-end RAG pipeline for EU regulatory queries.
+
+    Lazy-initialises the retriever and LLM service on first use so the class
+    can be imported without triggering network connections or heavy model loads.
+    """
+
+    def __init__(
+        self,
+        retriever=None,
+        llm_service=None,
+    ) -> None:
+        self._retriever = retriever
+        self._llm = llm_service
+
+    # ------------------------------------------------------------------
+    # Lazy initialisation
+    # ------------------------------------------------------------------
+
+    def _get_retriever(self):
+        if self._retriever is None:
+            from rag.retriever import RegulatoryRetriever  # noqa: PLC0415
+
+            self._retriever = RegulatoryRetriever()
+        return self._retriever
+
+    def _get_llm(self):
+        if self._llm is None:
+            from rag.llm import get_llm_service  # noqa: PLC0415
+
+            self._llm = get_llm_service()
+        return self._llm
+
+    # ------------------------------------------------------------------
+    # Core query
+    # ------------------------------------------------------------------
+
+    def query(
+        self,
+        question: str,
+        regulation: Optional[str] = None,
+        section_type: Optional[str] = None,
+        top_k: int = 5,
+        stream: bool = False,
+    ) -> Union[dict[str, Any], Iterator[str]]:
+        """Run the full RAG pipeline for *question*.
+
+        Args:
+            question:     The user's natural-language question.
+            regulation:   Optional filter (e.g. ``"DORA"`` or ``"NIS2"``).
+            section_type: Optional filter (e.g. ``"article"``).
+            top_k:        Number of context chunks to retrieve.
+            stream:       If ``True``, return a generator that yields answer
+                          chunks. The final yielded item is a special
+                          ``"__citations__"`` sentinel followed by JSON-encoded
+                          citations — callers that want citations in streaming
+                          mode should filter for it.
+
+        Returns:
+            * **Non-streaming** — ``{"answer": str, "citations": list[dict]}``
+            * **Streaming** — ``Iterator[str]`` of text chunks
+        """
+        retriever = self._get_retriever()
+
+        logger.info("RAG query: %r (top_k=%d, regulation=%s)", question[:80], top_k, regulation)
+
+        # 1. Retrieve relevant chunks
+        results = retriever.retrieve(
+            query=question,
+            regulation=regulation,
+            section_type=section_type,
+            top_k=top_k,
+        )
+
+        # 2. Build citations list
+        citations = _build_citations(results)
+
+        # 3. Assemble prompt
+        system_prompt, user_message = assemble_prompt(question, results)
+
+        llm = self._get_llm()
+
+        if stream:
+            return self._stream_query(llm, system_prompt, user_message, citations)
+
+        # 4. Call LLM (blocking)
+        answer = llm.complete(system=system_prompt, user=user_message)
+        logger.info("RAG answer generated (%d chars, %d citations)", len(answer), len(citations))
+
+        return {"answer": answer, "citations": citations}
+
+    # ------------------------------------------------------------------
+    # Streaming helper
+    # ------------------------------------------------------------------
+
+    def _stream_query(
+        self,
+        llm,
+        system_prompt: str,
+        user_message: str,
+        citations: list[dict[str, Any]],
+    ) -> Iterator[str]:
+        """Yield LLM chunks, then emit citations as a final sentinel."""
+        import json
+
+        for chunk in llm.stream(system=system_prompt, user=user_message):
+            yield chunk
+
+        # Yield citations as a structured sentinel for callers that need them
+        yield f"\n__citations__:{json.dumps(citations)}"
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _build_citations(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract citation metadata from retrieval results."""
+    citations = []
+    for res in results:
+        citations.append(
+            {
+                "regulation": res.get("regulation", ""),
+                "article": _article_label(res),
+                "score": round(res.get("score", 0.0), 4),
+                "citation": format_citation(res),
+            }
+        )
+    return citations
+
+
+def _article_label(result: dict[str, Any]) -> str:
+    """Return a compact article label like 'Article 5' or 'Recital 12'."""
+    section_type = (result.get("section_type") or "").capitalize()
+    section_number = result.get("section_number")
+    if section_type and section_number is not None:
+        return f"{section_type} {section_number}"
+    return section_type or ""
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience function
+# ---------------------------------------------------------------------------
+
+_default_chain: Optional[RAGChain] = None
+
+
+def query(
+    question: str,
+    regulation: Optional[str] = None,
+    section_type: Optional[str] = None,
+    top_k: int = 5,
+    stream: bool = False,
+) -> Union[dict[str, Any], Iterator[str]]:
+    """Convenience wrapper using a module-level singleton :class:`RAGChain`."""
+    global _default_chain
+    if _default_chain is None:
+        _default_chain = RAGChain()
+    return _default_chain.query(
+        question,
+        regulation=regulation,
+        section_type=section_type,
+        top_k=top_k,
+        stream=stream,
+    )

--- a/rag/llm.py
+++ b/rag/llm.py
@@ -1,0 +1,206 @@
+"""LLM integration — OpenAI GPT-4o and Ollama local fallback.
+
+Configured via environment variables:
+  LLM_PROVIDER=openai|ollama   (default: openai)
+  LLM_MODEL=gpt-4o|llama3      (default: gpt-4o)
+  OLLAMA_HOST=http://localhost:11434
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Generator, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Base protocol
+# ---------------------------------------------------------------------------
+
+
+class LLMService:
+    """Abstract base for LLM backends."""
+
+    def complete(self, system: str, user: str) -> str:
+        """Return a single complete response string."""
+        raise NotImplementedError
+
+    def stream(self, system: str, user: str) -> Iterator[str]:
+        """Yield response chunks as they arrive."""
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# OpenAI backend
+# ---------------------------------------------------------------------------
+
+
+class OpenAILLMService(LLMService):
+    """OpenAI chat-completion backend (default: gpt-4o)."""
+
+    def __init__(self, api_key: str, model: str = "gpt-4o") -> None:
+        self.api_key = api_key
+        self.model = model
+        self._client = None
+
+    def _get_client(self):
+        if self._client is None:
+            try:
+                from openai import OpenAI  # type: ignore
+
+                self._client = OpenAI(api_key=self.api_key)
+            except ImportError as exc:
+                raise ImportError(
+                    "openai package is required. Install with: pip install openai"
+                ) from exc
+        return self._client
+
+    def complete(self, system: str, user: str) -> str:
+        client = self._get_client()
+        logger.debug("OpenAI complete: model=%s", self.model)
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        )
+        return response.choices[0].message.content or ""
+
+    def stream(self, system: str, user: str) -> Iterator[str]:
+        client = self._get_client()
+        logger.debug("OpenAI stream: model=%s", self.model)
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            stream=True,
+        )
+        for chunk in response:
+            delta = chunk.choices[0].delta
+            if delta and delta.content:
+                yield delta.content
+
+
+# ---------------------------------------------------------------------------
+# Ollama backend
+# ---------------------------------------------------------------------------
+
+
+class OllamaLLMService(LLMService):
+    """Ollama local LLM backend via HTTP API."""
+
+    def __init__(self, host: str = "http://localhost:11434", model: str = "llama3") -> None:
+        self.host = host.rstrip("/")
+        self.model = model
+
+    def _get_client(self):
+        try:
+            import httpx  # type: ignore
+
+            return httpx.Client(timeout=120.0)
+        except ImportError as exc:
+            raise ImportError(
+                "httpx is required for Ollama. Install with: pip install httpx"
+            ) from exc
+
+    def complete(self, system: str, user: str) -> str:
+        logger.debug("Ollama complete: model=%s host=%s", self.model, self.host)
+        with self._get_client() as client:
+            payload = {
+                "model": self.model,
+                "messages": [
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                "stream": False,
+            }
+            resp = client.post(f"{self.host}/api/chat", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("message", {}).get("content", "")
+
+    def stream(self, system: str, user: str) -> Iterator[str]:
+        logger.debug("Ollama stream: model=%s host=%s", self.model, self.host)
+        try:
+            import httpx  # type: ignore
+        except ImportError as exc:
+            raise ImportError(
+                "httpx is required for Ollama. Install with: pip install httpx"
+            ) from exc
+
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "stream": True,
+        }
+        with httpx.Client(timeout=120.0) as client:
+            with client.stream("POST", f"{self.host}/api/chat", json=payload) as resp:
+                resp.raise_for_status()
+                for line in resp.iter_lines():
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    content = data.get("message", {}).get("content", "")
+                    if content:
+                        yield content
+                    if data.get("done"):
+                        break
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def get_llm_service(
+    provider: str | None = None,
+    model: str | None = None,
+    openai_api_key: str = "",
+    ollama_host: str = "",
+) -> LLMService:
+    """Return the configured LLM service.
+
+    Reads LLM_PROVIDER / LLM_MODEL from config if not passed explicitly.
+    """
+    if provider is None or model is None:
+        try:
+            from config import settings  # type: ignore
+
+            provider = provider or settings.llm_provider
+            model = model or settings.llm_model
+            openai_api_key = openai_api_key or settings.openai_api_key
+            ollama_host = ollama_host or settings.ollama_host
+        except Exception:  # noqa: BLE001
+            provider = provider or "openai"
+            model = model or "gpt-4o"
+
+    provider = (provider or "openai").lower()
+    model = model or "gpt-4o"
+
+    if provider == "openai":
+        if not openai_api_key:
+            raise ValueError(
+                "OPENAI_API_KEY must be set when using LLM_PROVIDER=openai."
+            )
+        logger.info("Using OpenAI LLM service (model=%s)", model)
+        return OpenAILLMService(api_key=openai_api_key, model=model)
+
+    if provider == "ollama":
+        host = ollama_host or "http://localhost:11434"
+        logger.info("Using Ollama LLM service (model=%s, host=%s)", model, host)
+        return OllamaLLMService(host=host, model=model)
+
+    raise ValueError(
+        f"Unknown LLM provider: {provider!r}. Expected 'openai' or 'ollama'."
+    )

--- a/rag/prompt.py
+++ b/rag/prompt.py
@@ -1,0 +1,116 @@
+"""Prompt assembly for EU regulatory RAG.
+
+Builds the system prompt and user message from retrieved chunks,
+injecting citation metadata and the user's question.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = """\
+You are an expert EU regulatory compliance assistant specialising in the Digital \
+Operational Resilience Act (DORA), the Network and Information Security Directive (NIS2), \
+and related EU financial and cybersecurity regulations.
+
+Your role is to provide precise, authoritative answers grounded exclusively in the \
+regulatory text provided to you. When answering:
+
+- Cite specific articles, chapters, and recitals by name and number.
+- Use the citation format: "According to [Regulation] Article [N] ([Title])..."
+- If the provided context does not contain sufficient information to answer the question,
+  say so clearly — do not speculate or invent regulatory provisions.
+- Structure complex answers with numbered or bulleted lists where appropriate.
+- Maintain a professional, compliance-oriented tone throughout.
+"""
+
+# ---------------------------------------------------------------------------
+# User message template
+# ---------------------------------------------------------------------------
+
+USER_TEMPLATE = (
+    "Based on the following regulatory excerpts:\n\n"
+    "{context}\n\n"
+    "Question: {query}\n\n"
+    "Provide a detailed answer with specific article references."
+)
+
+
+# ---------------------------------------------------------------------------
+# Citation helpers
+# ---------------------------------------------------------------------------
+
+
+def format_citation(result: dict[str, Any]) -> str:
+    """Format a single retrieval result as a citation string.
+
+    Example output:
+        "According to DORA Article 5 (ICT risk management framework)..."
+    """
+    regulation = result.get("regulation", "")
+    section_type = (result.get("section_type") or "").capitalize()
+    section_number = result.get("section_number")
+    section_title = result.get("section_title") or ""
+    chapter = result.get("chapter")
+
+    parts: list[str] = [f"According to {regulation}"]
+
+    if chapter:
+        parts.append(f"Chapter {chapter}")
+
+    if section_type and section_number is not None:
+        label = f"{section_type} {section_number}"
+        if section_title:
+            label = f"{label} ({section_title})"
+        parts.append(label)
+    elif section_type:
+        label = section_type
+        if section_title:
+            label = f"{label} ({section_title})"
+        parts.append(label)
+
+    return " — ".join(parts)
+
+
+def build_context_block(results: list[dict[str, Any]]) -> str:
+    """Convert a list of retrieval results into a numbered context block.
+
+    Each entry is prefixed with its citation, followed by the chunk text.
+    """
+    if not results:
+        return "No relevant regulatory text found for this query."
+
+    sections: list[str] = []
+    for i, res in enumerate(results, start=1):
+        citation = format_citation(res)
+        text = (res.get("text") or "").strip()
+        sections.append(f"[{i}] {citation}\n{text}")
+
+    return "\n\n---\n\n".join(sections)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def assemble_prompt(
+    query: str,
+    results: list[dict[str, Any]],
+) -> tuple[str, str]:
+    """Assemble the (system_prompt, user_message) pair for the LLM.
+
+    Args:
+        query:   The user's natural-language question.
+        results: Retrieved chunks from :meth:`RegulatoryRetriever.retrieve`.
+
+    Returns:
+        A ``(system, user)`` tuple ready to pass to any LLM service.
+    """
+    context = build_context_block(results)
+    user_message = USER_TEMPLATE.format(context=context, query=query)
+    return SYSTEM_PROMPT, user_message

--- a/rag/retriever.py
+++ b/rag/retriever.py
@@ -110,6 +110,19 @@ class RegulatoryRetriever:
         logger.info("Retrieved %d results for query %r", len(results), query[:80])
         return results
 
+    def format_citation(self, result: dict[str, Any]) -> str:
+        """Public helper — format a single retrieval result as a citation string.
+
+        Delegates to the module-level :func:`_build_citation` helper so callers
+        do not need to import private functions.
+
+        Example::
+
+            retriever.format_citation(result)
+            # → "According to DORA — Article 5 (ICT risk management framework):"
+        """
+        return _build_citation(result)
+
     def build_context(self, results: list[dict[str, Any]]) -> str:
         """Format retrieved results into a structured context string.
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,302 @@
+"""Tests for the RAG query layer: prompt assembly, citations, and the RAG chain."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures — sample retrieval results
+# ---------------------------------------------------------------------------
+
+DORA_RESULT: dict[str, Any] = {
+    "score": 0.921,
+    "regulation": "DORA",
+    "celex": "32022R2554",
+    "section_type": "article",
+    "section_number": "5",
+    "section_title": "ICT risk management framework",
+    "chapter": "II",
+    "topics": ["ict risk", "governance"],
+    "text": (
+        "Financial entities shall have in place a sound, comprehensive and well-documented "
+        "ICT risk management framework as part of their overall risk management system."
+    ),
+}
+
+NIS2_RESULT: dict[str, Any] = {
+    "score": 0.814,
+    "regulation": "NIS2",
+    "celex": "32022L2555",
+    "section_type": "article",
+    "section_number": "21",
+    "section_title": "Cybersecurity risk-management measures",
+    "chapter": "IV",
+    "topics": ["cybersecurity", "risk management"],
+    "text": (
+        "Member States shall ensure that essential and important entities take appropriate "
+        "and proportionate technical and organisational measures."
+    ),
+}
+
+MINIMAL_RESULT: dict[str, Any] = {
+    "score": 0.5,
+    "regulation": "DORA",
+    "celex": "",
+    "section_type": "",
+    "section_number": None,
+    "section_title": "",
+    "chapter": None,
+    "topics": [],
+    "text": "Some orphaned text chunk.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests — rag.prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCitation:
+    """Tests for rag.prompt.format_citation."""
+
+    def test_full_citation(self) -> None:
+        from rag.prompt import format_citation
+
+        citation = format_citation(DORA_RESULT)
+        assert "DORA" in citation
+        assert "Article" in citation
+        assert "5" in citation
+        assert "ICT risk management framework" in citation
+
+    def test_nis2_citation(self) -> None:
+        from rag.prompt import format_citation
+
+        citation = format_citation(NIS2_RESULT)
+        assert "NIS2" in citation
+        assert "21" in citation
+        assert "Cybersecurity risk-management measures" in citation
+
+    def test_citation_with_chapter(self) -> None:
+        from rag.prompt import format_citation
+
+        citation = format_citation(DORA_RESULT)
+        # Chapter is present in DORA_RESULT — should appear
+        assert "Chapter" in citation or "II" in citation
+
+    def test_minimal_result_no_crash(self) -> None:
+        from rag.prompt import format_citation
+
+        # Should not raise even with missing fields
+        citation = format_citation(MINIMAL_RESULT)
+        assert isinstance(citation, str)
+        assert "DORA" in citation
+
+    def test_missing_regulation_graceful(self) -> None:
+        from rag.prompt import format_citation
+
+        result = {**DORA_RESULT, "regulation": ""}
+        citation = format_citation(result)
+        assert isinstance(citation, str)
+
+
+class TestBuildContextBlock:
+    """Tests for rag.prompt.build_context_block."""
+
+    def test_empty_results(self) -> None:
+        from rag.prompt import build_context_block
+
+        context = build_context_block([])
+        assert "No relevant" in context
+
+    def test_numbered_entries(self) -> None:
+        from rag.prompt import build_context_block
+
+        context = build_context_block([DORA_RESULT, NIS2_RESULT])
+        assert "[1]" in context
+        assert "[2]" in context
+
+    def test_text_included(self) -> None:
+        from rag.prompt import build_context_block
+
+        context = build_context_block([DORA_RESULT])
+        assert DORA_RESULT["text"] in context
+
+    def test_separator_between_chunks(self) -> None:
+        from rag.prompt import build_context_block
+
+        context = build_context_block([DORA_RESULT, NIS2_RESULT])
+        assert "---" in context
+
+
+class TestAssemblePrompt:
+    """Tests for rag.prompt.assemble_prompt."""
+
+    def test_returns_two_strings(self) -> None:
+        from rag.prompt import assemble_prompt
+
+        system, user = assemble_prompt("What is DORA?", [DORA_RESULT])
+        assert isinstance(system, str)
+        assert isinstance(user, str)
+
+    def test_system_prompt_mentions_dora(self) -> None:
+        from rag.prompt import assemble_prompt
+
+        system, _ = assemble_prompt("test", [])
+        assert "DORA" in system
+
+    def test_user_message_contains_query(self) -> None:
+        from rag.prompt import assemble_prompt
+
+        question = "What are the ICT risk management obligations?"
+        _, user = assemble_prompt(question, [DORA_RESULT])
+        assert question in user
+
+    def test_user_message_contains_context(self) -> None:
+        from rag.prompt import assemble_prompt
+
+        _, user = assemble_prompt("test", [DORA_RESULT])
+        assert DORA_RESULT["text"] in user
+
+    def test_template_structure(self) -> None:
+        from rag.prompt import assemble_prompt
+
+        _, user = assemble_prompt("my question", [])
+        assert "Based on the following regulatory excerpts" in user
+        assert "Question: my question" in user
+        assert "Provide a detailed answer" in user
+
+
+# ---------------------------------------------------------------------------
+# Tests — rag.retriever (format_citation helper)
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieverFormatCitation:
+    """Tests for RegulatoryRetriever.format_citation."""
+
+    def test_public_helper_returns_string(self) -> None:
+        from rag.retriever import RegulatoryRetriever
+
+        retriever = RegulatoryRetriever()
+        citation = retriever.format_citation(DORA_RESULT)
+        assert isinstance(citation, str)
+        assert "DORA" in citation
+
+    def test_consistent_with_prompt_format_citation(self) -> None:
+        """Both helpers should produce equivalent output."""
+        from rag.prompt import format_citation as prompt_fmt
+        from rag.retriever import RegulatoryRetriever
+
+        retriever = RegulatoryRetriever()
+        retriever_citation = retriever.format_citation(DORA_RESULT)
+        # They use different implementations but should both contain key info
+        assert "DORA" in retriever_citation
+        assert "5" in retriever_citation
+
+
+# ---------------------------------------------------------------------------
+# Tests — rag.chain.RAGChain (fully mocked)
+# ---------------------------------------------------------------------------
+
+
+class MockLLMService:
+    """Test double for an LLM service."""
+
+    ANSWER = "Financial entities must implement a comprehensive ICT risk management framework per DORA Article 5."
+
+    def complete(self, system: str, user: str) -> str:
+        return self.ANSWER
+
+    def stream(self, system: str, user: str) -> Iterator[str]:
+        for word in self.ANSWER.split():
+            yield word + " "
+
+
+class MockRetriever:
+    """Test double for the regulatory retriever."""
+
+    def retrieve(self, query, regulation=None, section_type=None, top_k=5):
+        return [DORA_RESULT, NIS2_RESULT][:top_k]
+
+
+class TestRAGChain:
+    """Tests for rag.chain.RAGChain."""
+
+    def _make_chain(self) -> "RAGChain":
+        from rag.chain import RAGChain
+
+        return RAGChain(retriever=MockRetriever(), llm_service=MockLLMService())
+
+    def test_query_returns_answer_and_citations(self) -> None:
+        chain = self._make_chain()
+        result = chain.query("What are DORA ICT obligations?")
+        assert isinstance(result, dict)
+        assert "answer" in result
+        assert "citations" in result
+
+    def test_answer_is_nonempty_string(self) -> None:
+        chain = self._make_chain()
+        result = chain.query("test question")
+        assert isinstance(result["answer"], str)
+        assert len(result["answer"]) > 0
+
+    def test_citations_contain_regulation(self) -> None:
+        chain = self._make_chain()
+        result = chain.query("DORA question")
+        assert len(result["citations"]) > 0
+        for citation in result["citations"]:
+            assert "regulation" in citation
+            assert "article" in citation
+            assert "score" in citation
+
+    def test_citations_include_dora(self) -> None:
+        chain = self._make_chain()
+        result = chain.query("test")
+        regulations = {c["regulation"] for c in result["citations"]}
+        assert "DORA" in regulations
+
+    def test_top_k_limits_citations(self) -> None:
+        chain = self._make_chain()
+        result = chain.query("test", top_k=1)
+        # MockRetriever respects top_k
+        assert len(result["citations"]) <= 1
+
+    def test_streaming_yields_strings(self) -> None:
+        chain = self._make_chain()
+        chunks = list(chain.query("test", stream=True))
+        assert len(chunks) > 0
+        assert all(isinstance(c, str) for c in chunks)
+
+    def test_streaming_includes_citations_sentinel(self) -> None:
+        chain = self._make_chain()
+        chunks = list(chain.query("test", stream=True))
+        sentinel_chunks = [c for c in chunks if c.startswith("\n__citations__:")]
+        assert len(sentinel_chunks) == 1
+
+    def test_streaming_citations_are_valid_json(self) -> None:
+        chain = self._make_chain()
+        chunks = list(chain.query("test", stream=True))
+        sentinel = next(c for c in chunks if c.startswith("\n__citations__:"))
+        json_part = sentinel.split(":", 1)[1]
+        citations = json.loads(json_part)
+        assert isinstance(citations, list)
+
+    def test_regulation_filter_passed_to_retriever(self) -> None:
+        """Ensure the regulation filter is forwarded to the retriever."""
+        mock_retriever = MagicMock()
+        mock_retriever.retrieve.return_value = [DORA_RESULT]
+
+        from rag.chain import RAGChain
+
+        chain = RAGChain(retriever=mock_retriever, llm_service=MockLLMService())
+        chain.query("test", regulation="DORA")
+
+        mock_retriever.retrieve.assert_called_once()
+        call_kwargs = mock_retriever.retrieve.call_args
+        assert call_kwargs.kwargs.get("regulation") == "DORA" or (
+            len(call_kwargs.args) > 1 and call_kwargs.args[1] == "DORA"
+        )


### PR DESCRIPTION
## Summary

Implements the RAG query layer with LLM integration, prompt assembly, and streaming support.

**Closes #4**

## What's included

### LLM Integration (`rag/llm.py`)
- **OpenAI GPT-4o** as primary LLM backend
- **Ollama** local fallback (HTTP API at localhost:11434)
- Configurable via `LLM_PROVIDER` (openai|ollama) and `LLM_MODEL` env vars
- Streaming response support (yields chunks)
- `get_llm_service()` factory function

### Prompt Assembly (`rag/prompt.py`)
- System prompt: EU regulatory compliance expert persona
- Context injection with retrieved chunks + citation metadata
- Citation formatting: "According to DORA Article 5 (ICT risk management framework)..."
- `assemble_prompt()`, `format_citation()`, `build_context_block()`

### RAG Chain (`rag/chain.py`)
- `RAGChain.query(question, regulation, section_type, top_k, stream)`
- Orchestrates: embed query → retrieve from Qdrant → assemble prompt → call LLM
- Returns answer text + source citations [{regulation, article, score}]
- Streaming variant with citation sentinel (`__citations__:<json>`)
- Lazy init — safe for FastAPI startup

### Updated files
- `rag/retriever.py`: added `format_citation()` helper
- `config.py`: added LLM_PROVIDER, LLM_MODEL, OLLAMA_HOST
- `.env.example`: documented LLM vars

## Tests
- 25/25 passing (`tests/test_rag.py`)

## How to test
```bash
pip install -e '.[dev]'
python -m pytest tests/test_rag.py -v
```
