### PR TITLE
Add missing FastAPI app and container setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY api ./api
+COPY embeddings ./embeddings
+COPY ingestion ./ingestion
+COPY rag ./rag
+COPY vectordb ./vectordb
+COPY config.py ./
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -157,6 +157,33 @@ print(context)
 #   Financial entities shall have in place a sound, comprehensive and well-documented …
 ```
 
+## Running the API
+
+```bash
+uvicorn api.main:app --reload
+```
+
+Example requests:
+
+```bash
+curl http://localhost:8000/health
+
+curl -X POST http://localhost:8000/retrieve \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": "What are the ICT risk management requirements for financial entities?",
+    "regulation": "DORA",
+    "section_type": "article",
+    "top_k": 3
+  }'
+```
+
+Or start the API together with Qdrant via Docker Compose:
+
+```bash
+docker compose up --build api qdrant
+```
+
 ## Running Tests
 
 ```bash

--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
 import logging
 from typing import Any, Optional
 
@@ -11,6 +12,7 @@ from pydantic import BaseModel, Field
 from rag.retriever import RegulatoryRetriever
 
 logger = logging.getLogger(__name__)
+RETRIEVAL_FAILED_DETAIL = "Retrieval failed."
 
 app = FastAPI(
     title="EU Regulatory RAG API",
@@ -66,8 +68,9 @@ class RootResponse(BaseModel):
     endpoints: dict[str, str]
 
 
+@lru_cache
 def get_retriever() -> RegulatoryRetriever:
-    """Return the default retriever instance."""
+    """Return the shared default retriever instance."""
     return RegulatoryRetriever()
 
 
@@ -110,6 +113,6 @@ def retrieve(
         context = retriever.build_context(results)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Retrieval failed")
-        raise HTTPException(status_code=500, detail=f"Retrieval failed: {exc}") from exc
+        raise HTTPException(status_code=500, detail=RETRIEVAL_FAILED_DETAIL) from exc
 
     return RetrieveResponse(query=request.query, results=results, context=context)

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,115 @@
+"""FastAPI application exposing retrieval endpoints for the EU Regulatory RAG system."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from rag.retriever import RegulatoryRetriever
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="EU Regulatory RAG API",
+    version="0.1.0",
+    description="REST API for health checks and regulation retrieval.",
+)
+
+
+class RetrieveRequest(BaseModel):
+    """Request payload for semantic retrieval."""
+
+    query: str = Field(..., min_length=1, description="User question or search query")
+    regulation: Optional[str] = Field(default=None, description="Optional regulation filter")
+    section_type: Optional[str] = Field(default=None, description="Optional section type filter")
+    top_k: int = Field(default=5, ge=1, le=20, description="Maximum number of results")
+
+
+class RetrievalResult(BaseModel):
+    """Single retrieved chunk returned by the API."""
+
+    score: float
+    regulation: str
+    celex: str
+    section_type: str
+    section_number: Optional[str] = None
+    section_title: str
+    chapter: Optional[str] = None
+    topics: list[str] = Field(default_factory=list)
+    text: str
+
+
+class RetrieveResponse(BaseModel):
+    """Response payload for semantic retrieval."""
+
+    query: str
+    results: list[RetrievalResult]
+    context: str
+
+
+class HealthResponse(BaseModel):
+    """Health check response payload."""
+
+    status: str
+    service: str
+    version: str
+
+
+class RootResponse(BaseModel):
+    """Basic service metadata."""
+
+    service: str
+    version: str
+    endpoints: dict[str, str]
+
+
+def get_retriever() -> RegulatoryRetriever:
+    """Return the default retriever instance."""
+    return RegulatoryRetriever()
+
+
+@app.get("/", response_model=RootResponse)
+def root() -> RootResponse:
+    """Return basic API metadata."""
+    return RootResponse(
+        service="eu-regulatory-rag",
+        version=app.version,
+        endpoints={
+            "health": "/health",
+            "retrieve": "/retrieve",
+        },
+    )
+
+
+@app.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    """Liveness endpoint for local development and containers."""
+    return HealthResponse(
+        status="ok",
+        service="eu-regulatory-rag",
+        version=app.version,
+    )
+
+
+@app.post("/retrieve", response_model=RetrieveResponse)
+def retrieve(
+    request: RetrieveRequest,
+    retriever: RegulatoryRetriever = Depends(get_retriever),
+) -> RetrieveResponse:
+    """Retrieve regulation chunks and assemble an LLM-ready context."""
+    try:
+        results: list[dict[str, Any]] = retriever.retrieve(
+            query=request.query,
+            regulation=request.regulation,
+            section_type=request.section_type,
+            top_k=request.top_k,
+        )
+        context = retriever.build_context(results)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Retrieval failed")
+        raise HTTPException(status_code=500, detail=f"Retrieval failed: {exc}") from exc
+
+    return RetrieveResponse(query=request.query, results=results, context=context)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for the FastAPI application."""
 
+from unittest.mock import MagicMock
+
 from fastapi.testclient import TestClient
 
 from api.main import app, get_retriever
@@ -28,6 +30,11 @@ class FakeRetriever:
     def build_context(self, results):
         assert len(results) == 1
         return "[1] According to DORA — Article 6: Financial entities shall maintain an ICT risk management framework."
+
+
+class ExplodingRetriever:
+    def retrieve(self, query: str, regulation=None, section_type=None, top_k: int = 5):
+        raise RuntimeError("Qdrant connection to localhost:6333 failed")
 
 
 client = TestClient(app)
@@ -68,3 +75,35 @@ def test_retrieve_endpoint_uses_dependency_override():
     assert len(payload["results"]) == 1
     assert payload["results"][0]["section_number"] == "6"
     assert payload["context"].startswith("[1] According to DORA")
+
+
+def test_get_retriever_returns_cached_singleton(monkeypatch):
+    get_retriever.cache_clear()
+    factory = MagicMock(side_effect=[object()])
+    monkeypatch.setattr("api.main.RegulatoryRetriever", factory)
+
+    first = get_retriever()
+    second = get_retriever()
+
+    assert first is second
+    factory.assert_called_once_with()
+    get_retriever.cache_clear()
+
+
+def test_retrieve_endpoint_hides_backend_exception_details():
+    app.dependency_overrides[get_retriever] = lambda: ExplodingRetriever()
+    try:
+        response = client.post(
+            "/retrieve",
+            json={
+                "query": "What does DORA require?",
+                "regulation": "DORA",
+                "section_type": "article",
+                "top_k": 3,
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Retrieval failed."}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,70 @@
+"""Tests for the FastAPI application."""
+
+from fastapi.testclient import TestClient
+
+from api.main import app, get_retriever
+
+
+class FakeRetriever:
+    def retrieve(self, query: str, regulation=None, section_type=None, top_k: int = 5):
+        assert query == "What does DORA require?"
+        assert regulation == "DORA"
+        assert section_type == "article"
+        assert top_k == 3
+        return [
+            {
+                "score": 0.91,
+                "regulation": "DORA",
+                "celex": "32022R2554",
+                "section_type": "article",
+                "section_number": "6",
+                "section_title": "ICT risk management framework",
+                "chapter": "II",
+                "topics": ["ict_risk"],
+                "text": "Financial entities shall maintain an ICT risk management framework.",
+            }
+        ]
+
+    def build_context(self, results):
+        assert len(results) == 1
+        return "[1] According to DORA — Article 6: Financial entities shall maintain an ICT risk management framework."
+
+
+client = TestClient(app)
+
+
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["service"] == "eu-regulatory-rag"
+    assert payload["endpoints"]["retrieve"] == "/retrieve"
+
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_retrieve_endpoint_uses_dependency_override():
+    app.dependency_overrides[get_retriever] = lambda: FakeRetriever()
+    try:
+        response = client.post(
+            "/retrieve",
+            json={
+                "query": "What does DORA require?",
+                "regulation": "DORA",
+                "section_type": "article",
+                "top_k": 3,
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["query"] == "What does DORA require?"
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["section_number"] == "6"
+    assert payload["context"].startswith("[1] According to DORA")


### PR DESCRIPTION
## Summary
- add a FastAPI app with root, health, and retrieval endpoints
- add API tests with dependency overrides so the HTTP layer is covered without hitting external services
- add a Dockerfile and README usage notes so `docker compose up --build api qdrant` works as documented

## Review notes
- `api/main.py` was empty, so the advertised REST API could not be started
- `docker-compose.yml` referenced `build: .`, but the repository had no `Dockerfile`, so the API service could not be built

## Validation
- `pytest -q` (35 passed, 1 warning about local `pytest-asyncio` not being installed in this environment)
